### PR TITLE
Support verse range highlighting in reader

### DIFF
--- a/imba/src/lib/GenericReader.imba
+++ b/imba/src/lib/GenericReader.imba
@@ -21,6 +21,7 @@ class GenericReader
 	@observable bookmarks\Bookmark[] = []
 	show_verse_picker\boolean = no
 	verse\number|string = 0
+	linkedVerses\number[] = []
 
 	me = '' # constant to indicate the main reader versus the parallel reader
 
@@ -246,27 +247,19 @@ class GenericReader
 
 
 	def highlightLinkedVerses verseNumber, endverse
-		if !window.getSelection
-			return
+		linkedVerses = []
 
-		setTimeout(&, 250) do
-			const verseNode = document.getElementById(verseNumber)
-			unless verseNode
-				return highlightLinkedVerses verseNumber, endverse
+		const start = parseInt(verseNumber)
+		const finish = endverse ? parseInt(endverse) : start
 
-			const selection = window.getSelection()
-			selection.removeAllRanges()
-			if endverse
-				for id in [parseInt(verseNumber) .. parseInt(endverse)]
-					if id <= verses.length
-						const range = document.createRange()
-						const node = document.getElementById(String(id))
-						range.selectNodeContents(node)
-						selection.addRange(range)
-			else
-				const range = document.createRange()
-				range.selectNodeContents(verseNode)
-				selection.addRange(range)
+		for id in [start .. finish]
+			if id <= verses.length
+				linkedVerses.push(id)
+
+		imba.commit!
+
+	def isLinkedVerse verseNumber\number
+		return linkedVerses.includes(verseNumber)
 
 	def saveBookmark
 		unless user.username

--- a/imba/src/lib/GenericReader.imba
+++ b/imba/src/lib/GenericReader.imba
@@ -156,6 +156,8 @@ class GenericReader
 		if activities.selectedParallel != undefined and activities.selectedParallel != me
 			return
 
+		clearLinkedVerses!
+
 		activities.selectedParallel = me
 		activities.highlight_color = activities.randomColor
 
@@ -246,8 +248,13 @@ class GenericReader
 				findVerse(id, endverse, highlight)
 
 
+	def clearLinkedVerses
+		if linkedVerses.length
+			linkedVerses = []
+			imba.commit!
+
 	def highlightLinkedVerses verseNumber, endverse
-		linkedVerses = []
+		clearLinkedVerses!
 
 		const start = parseInt(verseNumber)
 		const finish = endverse ? parseInt(endverse) : start

--- a/imba/src/lib/GenericReader.imba
+++ b/imba/src/lib/GenericReader.imba
@@ -21,7 +21,6 @@ class GenericReader
 	@observable bookmarks\Bookmark[] = []
 	show_verse_picker\boolean = no
 	verse\number|string = 0
-	linkedVerses\number[] = []
 
 	me = '' # constant to indicate the main reader versus the parallel reader
 
@@ -112,19 +111,6 @@ class GenericReader
 				return  "linear-gradient({highlight.color} 0px, {highlight.color} 100%)"
 			else
 				return ''
-
-	def getLinkedHighlight
-		let width = Math.ceil(0.5 * theme.fontSize)
-		return "repeating-linear-gradient(90deg, var(--acc), var(--acc) {width}px, rgba(0,0,0,0) {width}px, rgba(0,0,0,0) {width * 2}px)"
-
-	def getVerseHighlight pk\number, verseNumber\number
-		let backgrounds = []
-		const savedHighlight = getHighlight(pk)
-		if savedHighlight
-			backgrounds.push(savedHighlight)
-		if isLinkedVerse(verseNumber)
-			backgrounds.push(getLinkedHighlight!)
-		return backgrounds.join(', ')
 	
 	def getBookmarks
 		if !user.username
@@ -168,8 +154,6 @@ class GenericReader
 
 		if activities.selectedParallel != undefined and activities.selectedParallel != me
 			return
-
-		clearLinkedVerses!
 
 		activities.selectedParallel = me
 		activities.highlight_color = activities.randomColor
@@ -218,6 +202,31 @@ class GenericReader
 			activities.activeVerseAction = undefined
 			activities.selectedParallel = undefined
 
+	def selectVersesRange verseNumber, endverse = undefined
+		const start = parseInt(verseNumber)
+		const finish = endverse ? parseInt(endverse) : start
+
+		activities.selectedParallel = me
+		if !activities.highlight_color
+			activities.highlight_color = activities.randomColor
+		activities.selectedVerses = []
+		activities.selectedVersesPKs = []
+		activities.selectedCategories = []
+
+		for verse in verses when start <= verse.verse <= finish
+			activities.selectedVersesPKs.push(verse.pk)
+			activities.selectedVerses.push(verse.verse)
+			pushCollectionIfExist(verse.pk)
+
+		if activities.selectedVersesPKs.length
+			mergeNotes!
+			activities.activeVerseAction = 'options'
+		else
+			activities.activeVerseAction = undefined
+			activities.selectedParallel = undefined
+
+		imba.commit!
+
 
 	def mergeNotes
 		activities.note = ''
@@ -256,30 +265,9 @@ class GenericReader
 					behavior: theme.scrollBehavior,
 					top: verseNumberElement.offsetTop - theme.fontSize
 				})
-				if highlight then highlightLinkedVerses(id, endverse)
+				if highlight then selectVersesRange(id, endverse)
 			else
 				findVerse(id, endverse, highlight)
-
-
-	def clearLinkedVerses
-		if linkedVerses.length
-			linkedVerses = []
-			imba.commit!
-
-	def highlightLinkedVerses verseNumber, endverse
-		clearLinkedVerses!
-
-		const start = parseInt(verseNumber)
-		const finish = endverse ? parseInt(endverse) : start
-
-		for id in [start .. finish]
-			if id <= verses.length
-				linkedVerses.push(id)
-
-		imba.commit!
-
-	def isLinkedVerse verseNumber\number
-		return linkedVerses.includes(verseNumber)
 
 	def saveBookmark
 		unless user.username

--- a/imba/src/lib/GenericReader.imba
+++ b/imba/src/lib/GenericReader.imba
@@ -112,6 +112,19 @@ class GenericReader
 				return  "linear-gradient({highlight.color} 0px, {highlight.color} 100%)"
 			else
 				return ''
+
+	def getLinkedHighlight
+		let width = Math.ceil(0.5 * theme.fontSize)
+		return "repeating-linear-gradient(90deg, var(--acc), var(--acc) {width}px, rgba(0,0,0,0) {width}px, rgba(0,0,0,0) {width * 2}px)"
+
+	def getVerseHighlight pk\number, verseNumber\number
+		let backgrounds = []
+		const savedHighlight = getHighlight(pk)
+		if savedHighlight
+			backgrounds.push(savedHighlight)
+		if isLinkedVerse(verseNumber)
+			backgrounds.push(getLinkedHighlight!)
+		return backgrounds.join(', ')
 	
 	def getBookmarks
 		if !user.username

--- a/imba/src/lib/GenericReader.imba
+++ b/imba/src/lib/GenericReader.imba
@@ -213,7 +213,7 @@ class GenericReader
 		activities.selectedVersesPKs = []
 		activities.selectedCategories = []
 
-		for verse in verses when start <= verse.verse <= finish
+		for verse in verses when verse.verse >= start and verse.verse <= finish
 			activities.selectedVersesPKs.push(verse.pk)
 			activities.selectedVerses.push(verse.verse)
 			pushCollectionIfExist(verse.pk)

--- a/imba/src/lib/ParallelReader.imba
+++ b/imba/src/lib/ParallelReader.imba
@@ -83,7 +83,6 @@ class ParallelReader < GenericReader
 				findVerse(verse, undefined, yes)
 			verse = undefined
 		else
-			clearLinkedVerses!
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0

--- a/imba/src/lib/ParallelReader.imba
+++ b/imba/src/lib/ParallelReader.imba
@@ -83,6 +83,7 @@ class ParallelReader < GenericReader
 				findVerse(verse, undefined, yes)
 			verse = undefined
 		else
+			linkedVerses = []
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0

--- a/imba/src/lib/ParallelReader.imba
+++ b/imba/src/lib/ParallelReader.imba
@@ -83,7 +83,7 @@ class ParallelReader < GenericReader
 				findVerse(verse, undefined, yes)
 			verse = undefined
 		else
-			linkedVerses = []
+			clearLinkedVerses!
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0

--- a/imba/src/lib/Reader.imba
+++ b/imba/src/lib/Reader.imba
@@ -36,7 +36,7 @@ class Reader < GenericReader
 				translation = window.translation
 				book = window.book
 				chapter = window.chapter
-				verse = window.verse
+				verse = window.endVerse ? "{window.verse}-{window.endVerse}" : window.verse
 			verses = window.verses
 			loading = no
 		else
@@ -80,14 +80,16 @@ class Reader < GenericReader
 		readingHistory.saveToHistory(translation, book, chapter, verse)
 		getBookmarks!
 
-		if verse
-			if typeof verse === 'string' and verse.includes('-')
-				const parts = verse.split('-')
+		const linkedVerse = verse
+		if linkedVerse
+			if typeof linkedVerse === 'string' and linkedVerse.includes('-')
+				const parts = linkedVerse.split('-')
 				findVerse(parts[0], parts[1], yes)
 			else
-				findVerse(verse, undefined, yes)
+				findVerse(linkedVerse, undefined, yes)
 			verse = undefined
 		else
+			linkedVerses = []
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0
@@ -95,7 +97,9 @@ class Reader < GenericReader
 		# if the pathname has one of 4 `/` in it then call the pushState
 		const pathnameSlices = window.location.pathname.split('/').filter(Boolean).length
 		if pathnameSlices == 0 or pathnameSlices > 2
-			const newLocation = window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/'
+			let newLocation = window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/'
+			if linkedVerse
+				newLocation = window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/' + linkedVerse + '/'
 			if window.location.href != newLocation
 				window.history.pushState({
 						translation: translation,
@@ -103,7 +107,7 @@ class Reader < GenericReader
 						chapter: chapter,
 					},
 					'',
-					window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/'
+					newLocation
 				)
 
 	@action def randomVerse

--- a/imba/src/lib/Reader.imba
+++ b/imba/src/lib/Reader.imba
@@ -87,7 +87,6 @@ class Reader < GenericReader
 			else
 				findVerse(verse, undefined, yes)
 		else
-			clearLinkedVerses!
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0

--- a/imba/src/lib/Reader.imba
+++ b/imba/src/lib/Reader.imba
@@ -80,16 +80,14 @@ class Reader < GenericReader
 		readingHistory.saveToHistory(translation, book, chapter, verse)
 		getBookmarks!
 
-		const linkedVerse = verse
-		if linkedVerse
-			if typeof linkedVerse === 'string' and linkedVerse.includes('-')
-				const parts = linkedVerse.split('-')
+		if verse
+			if typeof verse === 'string' and verse.includes('-')
+				const parts = verse.split('-')
 				findVerse(parts[0], parts[1], yes)
 			else
-				findVerse(linkedVerse, undefined, yes)
-			verse = undefined
+				findVerse(verse, undefined, yes)
 		else
-			linkedVerses = []
+			clearLinkedVerses!
 			show_verse_picker = yes
 			if myRenderer
 				myRenderer.scrollTop = 0
@@ -98,8 +96,8 @@ class Reader < GenericReader
 		const pathnameSlices = window.location.pathname.split('/').filter(Boolean).length
 		if pathnameSlices == 0 or pathnameSlices > 2
 			let newLocation = window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/'
-			if linkedVerse
-				newLocation = window.location.origin + '/' + translation + '/' + book + '/' + chapter + '/' + linkedVerse + '/'
+			if verse
+				newLocation += verse + '/'
 			if window.location.href != newLocation
 				window.history.pushState({
 						translation: translation,
@@ -109,6 +107,9 @@ class Reader < GenericReader
 					'',
 					newLocation
 				)
+
+		if verse
+			verse = undefined
 
 	@action def randomVerse
 		try

--- a/imba/src/ui/chapter.imba
+++ b/imba/src/ui/chapter.imba
@@ -147,7 +147,7 @@ tag chapter < section
 								# make it focus-able to get keydown working on it
 								tabIndex=0
 								@keydown.enter=me.saveBookmark
-								[background-image: {me.getVerseHighlight(verse.pk, verse.verse)} scroll-margin-top: 1.4rem]
+								[background-image: {me.getHighlight(verse.pk)} scroll-margin-top: 1.4rem]
 							>
 						
 						if bookmark and not me.nextVerseHasTheSameBookmark(verse_index) and (bookmark.collection || bookmark.note)

--- a/imba/src/ui/chapter.imba
+++ b/imba/src/ui/chapter.imba
@@ -147,7 +147,7 @@ tag chapter < section
 								# make it focus-able to get keydown working on it
 								tabIndex=0
 								@keydown.enter=me.saveBookmark
-								[background-image: {me.getHighlight(verse.pk)} background-color: {me.isLinkedVerse(verse.verse) ? 'var(--acc-bgc-hover)' : 'transparent'} scroll-margin-top: 1.4rem]
+								[background-image: {me.getVerseHighlight(verse.pk, verse.verse)} scroll-margin-top: 1.4rem]
 							>
 						
 						if bookmark and not me.nextVerseHasTheSameBookmark(verse_index) and (bookmark.collection || bookmark.note)

--- a/imba/src/ui/chapter.imba
+++ b/imba/src/ui/chapter.imba
@@ -147,7 +147,7 @@ tag chapter < section
 								# make it focus-able to get keydown working on it
 								tabIndex=0
 								@keydown.enter=me.saveBookmark
-								[background-image: {me.getHighlight(verse.pk)} scroll-margin-top: 1.4rem]
+								[background-image: {me.getHighlight(verse.pk)} background-color: {me.isLinkedVerse(verse.verse) ? 'var(--acc-bgc-hover)' : 'transparent'} scroll-margin-top: 1.4rem]
 							>
 						
 						if bookmark and not me.nextVerseHasTheSameBookmark(verse_index) and (bookmark.collection || bookmark.note)

--- a/imba/src/ui/verse-actions.imba
+++ b/imba/src/ui/verse-actions.imba
@@ -28,6 +28,25 @@ tag verse-actions < section
 	#dy = DEFAULT_Y
 	categoriesSearch = ''
 
+	def updateBottomDrawerOffset
+		setTimeout(&, 0) do
+			if self.isConnected
+				activities.bottomDrawerOffset = self.offsetHeight
+
+	def mount
+		updateBottomDrawerOffset!
+
+	def unmount
+		activities.bottomDrawerOffset = 0
+
+	@autorun
+	def syncBottomDrawerOffset
+		activities.selectedVersesTitle
+		activities.show_sharing
+		activities.show_bookmarks
+		activities.show_add_bookmark
+		updateBottomDrawerOffset!
+
 	def close
 		# should await for the transition-duration property update to achieve smoothness
 		#dy = DEFAULT_Y


### PR DESCRIPTION
## Summary
- support direct verse range URLs like `/ESV/1/12/1-3/`
- map linked range URLs onto the existing verse selection flow instead of a separate highlight path
- reuse the existing verse highlight styling and open the existing verse actions bottom sheet for linked ranges
- preserve the verse range in the URL when loading the chapter