### PR TITLE
Parse Bible references in search with grab-bcv

### DIFF
--- a/django/bolls/static/imba/package-lock.json
+++ b/django/bolls/static/imba/package-lock.json
@@ -18,6 +18,7 @@
         "colorjs.io": "^0.6.1",
         "date-fns": "^4.1.0",
         "dompurify": "^3.3.3",
+        "grab-bcv": "^0.1.5",
         "imba": "^2.0.0-alpha.247",
         "imba-phosphor-icons": "^2.2.0",
         "lucide-static": "^0.575.0",
@@ -1095,6 +1096,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/grab-bcv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/grab-bcv/-/grab-bcv-0.1.5.tgz",
+      "integrity": "sha512-VNT6MWZEw1TEOYa7wVeS5Ct18OdBMx1Yy1rjvOuYyPLU8IHR8daADU4nRDb5O/vi7fFhI++CgvIgDjfNT3b7ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/dpshade"
       }
     },
     "node_modules/human-signals": {

--- a/django/bolls/static/imba/package.json
+++ b/django/bolls/static/imba/package.json
@@ -20,6 +20,7 @@
     "colorjs.io": "^0.6.1",
     "date-fns": "^4.1.0",
     "dompurify": "^3.3.3",
+    "grab-bcv": "^0.1.5",
     "imba": "^2.0.0-alpha.247",
     "imba-phosphor-icons": "^2.2.0",
     "lucide-static": "^0.575.0",

--- a/django/bolls/static/imba/src/lib/Search.imba
+++ b/django/bolls/static/imba/src/lib/Search.imba
@@ -1,4 +1,7 @@
+import ALL_BOOKS from '../data/translations_books.json'
 import { setValue, getValue, scoreSearch } from '../utils'
+import { getBookId } from '../../utils/books'
+import { findAnyPassage } from 'grab-bcv'
 
 import activities from './Activities'
 import API from './Api'
@@ -56,11 +59,121 @@ class Search
 					suggested_translations.push(translation)
 		return suggested_translations
 
+	def getBooksForTranslation translationName\string
+		return ALL_BOOKS[translationName] || ALL_BOOKS['YLT']
+
+	def getBookForTranslation translationName\string, bookId\number
+		return getBooksForTranslation(translationName).find(do |book| return book.bookid == bookId)
+
+	def findExactTranslation query\string
+		const normalizedQuery = query.trim!.toLowerCase!
+		unless normalizedQuery.length
+			return null
+
+		for translation in translations
+			if normalizedQuery == translation.short_name.toLowerCase! or normalizedQuery == translation.full_name.toLowerCase!
+				return translation
+
+		return null
+
+	def normalizeReferenceQuery query\string
+		const trimmedQuery = query.trim!
+		unless trimmedQuery.length
+			return trimmedQuery
+
+		let normalizedQuery = trimmedQuery
+
+		try
+			let possibleUrl = trimmedQuery
+			if !/^https?:\/\//i.test(possibleUrl) and possibleUrl.includes('/')
+				possibleUrl = 'https://' + possibleUrl
+
+			if /^https?:\/\//i.test(possibleUrl)
+				const parsedUrl = new URL(possibleUrl)
+				const pathParts = parsedUrl.pathname.split('/').filter(Boolean)
+				if pathParts.length
+					normalizedQuery = window.decodeURIComponent(pathParts[-1])
+		catch error
+			normalizedQuery = trimmedQuery
+
+		return normalizedQuery
+
+	def parseReferenceQuery query\string
+		const trimmedQuery = normalizeReferenceQuery(query)
+		unless trimmedQuery.length
+			return null
+
+		let referenceTranslation = translation
+		const lastWord = trimmedQuery.split(/\s+/)[-1]
+		const matchedTranslation = findExactTranslation(lastWord)
+		if matchedTranslation and trimmedQuery.split(/\s+/).length > 1
+			referenceTranslation = matchedTranslation.short_name
+
+		const parsedReference = findAnyPassage(trimmedQuery)
+		if !parsedReference or Array.isArray(parsedReference)
+			return null
+
+		let bookId
+		try
+			bookId = parseInt(getBookId(referenceTranslation, parsedReference.start.book))
+		catch error
+			console.warn('Failed to resolve book from parsed reference', error)
+			return null
+
+		const parsedBook = getBookForTranslation(referenceTranslation, bookId)
+		unless parsedBook and parsedBook.chapters >= parsedReference.start.chapter
+			return null
+
+		let verse = undefined
+		if parsedReference.rangeType == 'single' and parsedReference.start.verse
+			verse = parsedReference.start.verse
+		elif parsedReference.rangeType == 'same_chapter' and parsedReference.start.verse and parsedReference.end.verse
+			verse = "{parsedReference.start.verse}-{parsedReference.end.verse}"
+		elif parsedReference.rangeType == 'cross_reference' and parsedReference.start.verse
+			verse = parsedReference.start.verse
+
+		return {
+			translation: referenceTranslation
+			book: bookId
+			chapter: parsedReference.start.chapter
+			verse: verse
+		}
+
+	def openReferenceQuery result
+		const sameChapter = reader.translation == result.translation and reader.book == result.book and reader.chapter == result.chapter
+
+		reader.translation = result.translation
+		reader.book = result.book
+		reader.chapter = result.chapter
+		reader.verse = result.verse
+
+		if sameChapter and result.verse
+			if typeof result.verse == 'string' and result.verse.includes('-')
+				const parts = result.verse.split('-')
+				reader.findVerse(parts[0], parts[1], yes)
+			else
+				reader.findVerse(result.verse, undefined, yes)
+		elif !sameChapter
+			reader.fetchVerses!
+
+		activities.cleanUp!
+		return yes
+
 	@autorun
 	def generateSuggestions
 		const trimmedQuery = query.trim!.toLowerCase!
 		unless trimmedQuery.length
 			suggestions = {}
+			return
+
+		const parsedReference = parseReferenceQuery(query)
+		if parsedReference
+			const parsedBook = getBookForTranslation(parsedReference.translation, parsedReference.book)
+			suggestions.chapter = parsedReference.chapter
+			suggestions.verse = parsedReference.verse
+			suggestions.translation = parsedReference.translation
+			suggestions.books = parsedBook ? [parsedBook] : []
+			suggestions.translations = []
 			return
 
 		const parts = trimmedQuery.split(' ')
@@ -81,7 +194,7 @@ class Search
 				const ch_v_numbers = numbers_part.split(':')
 				suggestions.chapter = parseInt(ch_v_numbers[0])
 				if ch_v_numbers[1].length
-					suggestions.verse = parseInt(ch_v_numbers[1])
+					suggestions.verse = ch_v_numbers[1]
 			else
 				suggestions.chapter = parseInt(numbers_part)
 
@@ -127,6 +240,10 @@ class Search
 		return !isNaN(str) && !isNaN(parseFloat(str))
 
 	def run
+		const parsedReference = parseReferenceQuery(query)
+		if parsedReference
+			return openReferenceQuery(parsedReference)
+
 		# Clear the searched text to avoid 400 error
 		# If the query is long enough -- do the search
 		if query.length <= 2 && !isNumber(query)


### PR DESCRIPTION
## Summary
- add `grab-bcv`, a Bible citation parser that extracts book, chapter, verse, and same-chapter ranges from free-form input
- use it in search before falling back to the existing text search flow
- support pasted reference-like URLs by normalizing inputs like `route.bible/php.4.11-13` before parsing

This makes inputs such as `John 3:16`, `Matthew 12:1-3`, and `route.bible/php.4.11-13` open the matching passage instead of being treated as plain text search.

## Testing
- `npm run build`